### PR TITLE
Class name to match example in readme.

### DIFF
--- a/examples/Post_Type_Recipe.php
+++ b/examples/Post_Type_Recipe.php
@@ -19,7 +19,7 @@ use Gamajo\Registerable\Post_Type;
  * @package Meal_Planner
  * @author  Gary Jones
  */
-class Recipe extends Post_Type {
+class Post_Type_Recipe extends Post_Type {
 	/**
 	 * Post type ID.
 	 *


### PR DESCRIPTION
Example snippet in the readme uses `$prefix_post_type_recipe = new Gamajo\MealPlanner\Post_Type_Recipe;`, so class name needs to be Post_Type_Recipe.
